### PR TITLE
118 - Seed Flow Phrase Bug Fixes

### DIFF
--- a/DSNP-Wallet/Source/Common/Extension/Theme/UIColor+Theme.swift
+++ b/DSNP-Wallet/Source/Common/Extension/Theme/UIColor+Theme.swift
@@ -28,7 +28,7 @@ extension UIColor {
         static var buttonOrange: UIColor { return UIColor(red: 218/255, green: 94/255, blue: 58/255, alpha: 1)}
         static var buttonGray: UIColor { return UIColor(red: 242/255, green: 242/255, blue: 242/255, alpha: 1)}
         static var termsTextColor: UIColor { return UIColor(red: 47/255, green: 52/255, blue: 55/255, alpha: 1)}
-
+        static var errorStringColor: UIColor { return UIColor(red: 251/255, green: 11/255, blue: 11/255, alpha: 1)}
 
     }
 }

--- a/DSNP-Wallet/Source/Common/Views/SwiftUI/Button.swift
+++ b/DSNP-Wallet/Source/Common/Views/SwiftUI/Button.swift
@@ -49,6 +49,7 @@ struct SecondaryButton: View {
     
     var body: some View {
         Button {
+            action()
         } label: {
             Text(title)
                 .font(Font(UIFont.Theme.bold(ofSize: 15)))

--- a/DSNP-Wallet/Source/Modules/Onboarding/SeedPhrase/SwiftUI/SeedPhraseTestView.swift
+++ b/DSNP-Wallet/Source/Modules/Onboarding/SeedPhrase/SwiftUI/SeedPhraseTestView.swift
@@ -26,8 +26,6 @@ struct SeedPhraseTestView: View {
     
     @ObservedObject var viewModel: SeedPuzzleViewModel
     
-    @State private var showingAlert = false
-
     var body: some View {
         VStack(alignment: .leading) {
             title
@@ -42,6 +40,7 @@ struct SeedPhraseTestView: View {
                 .padding(.vertical, 14)
                 .padding(.horizontal, 20)
                 .frame(maxWidth: .infinity, alignment: .center)
+            errorMessage
             SeedPhraseWordBank(viewModel: viewModel)
                 .padding(.horizontal, 14)
             continueButton
@@ -72,11 +71,7 @@ struct SeedPhraseTestView: View {
         SecondaryButton(title: "Continue") {
             if viewModel.continueEnabled {
                 viewModel.continueAction.send()
-                showingAlert = true
             }
-        }
-        .alert(viewModel.seedphraseAlertString, isPresented: $showingAlert) {
-            Button("OK", role: .cancel) { }
         }
         .padding(.horizontal, 30)
         .padding(.vertical, 18)
@@ -89,6 +84,14 @@ struct SeedPhraseTestView: View {
             .foregroundColor(.white)
             .font(Font(UIFont.Theme.regular(ofSize: 14)))
             .frame(alignment: .center)
+    }
+    
+    private var errorMessage: some View {
+        Text(viewModel.errorMessage)
+            .foregroundColor(viewModel.isPuzzleCorrect() ? .green : Color(uiColor: UIColor.Theme.errorStringColor))
+            .font(Font(UIFont.Theme.bold(ofSize: 12)))
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding()
     }
 }
 

--- a/DSNP-Wallet/Source/Modules/Onboarding/SeedPhrase/SwiftUI/SeedPhraseTestView.swift
+++ b/DSNP-Wallet/Source/Modules/Onboarding/SeedPhrase/SwiftUI/SeedPhraseTestView.swift
@@ -126,9 +126,9 @@ struct SeedPhraseButton: View {
                     .foregroundColor(.white)
                     .font(Font(UIFont.Theme.spaceRegular(ofSize: 15)))
             }
-            .frame(minWidth: 110, alignment: .leading)
+            .frame(minWidth: 130, alignment: .leading)
         }
-        .frame(minWidth: 110, minHeight: 25)
+        .frame(minWidth: 130, minHeight: 25)
         .background(element != nil ? Color(uiColor: UIColor.Theme.buttonOrange) : .clear)
         .overlay(
             RoundedRectangle(cornerRadius: 40)

--- a/DSNP-Wallet/Source/Modules/Onboarding/SeedPhrase/SwiftUI/SeedPhraseTestView.swift
+++ b/DSNP-Wallet/Source/Modules/Onboarding/SeedPhrase/SwiftUI/SeedPhraseTestView.swift
@@ -88,7 +88,7 @@ struct SeedPhraseTestView: View {
     
     private var errorMessage: some View {
         Text(viewModel.errorMessage)
-            .foregroundColor(viewModel.isPuzzleCorrect() ? Color(.green) : Color(uiColor: UIColor.Theme.errorStringColor))
+            .foregroundColor(viewModel.errorMessageColor)
             .font(Font(UIFont.Theme.bold(ofSize: 12)))
             .frame(maxWidth: .infinity, alignment: .center)
             .padding()

--- a/DSNP-Wallet/Source/Modules/Onboarding/SeedPhrase/SwiftUI/SeedPhraseTestView.swift
+++ b/DSNP-Wallet/Source/Modules/Onboarding/SeedPhrase/SwiftUI/SeedPhraseTestView.swift
@@ -88,7 +88,7 @@ struct SeedPhraseTestView: View {
     
     private var errorMessage: some View {
         Text(viewModel.errorMessage)
-            .foregroundColor(viewModel.isPuzzleCorrect() ? .green : Color(uiColor: UIColor.Theme.errorStringColor))
+            .foregroundColor(viewModel.isPuzzleCorrect() ? Color(.green) : Color(uiColor: UIColor.Theme.errorStringColor))
             .font(Font(UIFont.Theme.bold(ofSize: 12)))
             .frame(maxWidth: .infinity, alignment: .center)
             .padding()

--- a/DSNP-Wallet/Source/Modules/Onboarding/SeedPhrase/SwiftUI/SeedPhraseTestView.swift
+++ b/DSNP-Wallet/Source/Modules/Onboarding/SeedPhrase/SwiftUI/SeedPhraseTestView.swift
@@ -75,7 +75,7 @@ struct SeedPhraseTestView: View {
                 showingAlert = true
             }
         }
-        .alert("You got the test \(viewModel.isPuzzleCorrect() ? "Correct" : "Wrong")", isPresented: $showingAlert) {
+        .alert(viewModel.seedphraseAlertString, isPresented: $showingAlert) {
             Button("OK", role: .cancel) { }
         }
         .padding(.horizontal, 30)

--- a/DSNP-Wallet/Source/Modules/Onboarding/SeedPhrase/SwiftUI/SeedPhraseView.swift
+++ b/DSNP-Wallet/Source/Modules/Onboarding/SeedPhrase/SwiftUI/SeedPhraseView.swift
@@ -44,7 +44,7 @@ struct SeedPhraseView: View {
     }
     
     private var headline: some View {
-        Text("Headline goes here")
+        Text("Security is important")
             .foregroundColor(.white)
             .font(Font(UIFont.Theme.bold(ofSize: 22)))
             .padding(.horizontal, 16)

--- a/DSNP-Wallet/Source/Modules/Onboarding/SeedPhrase/SwiftUI/SeedPuzzleViewModel.swift
+++ b/DSNP-Wallet/Source/Modules/Onboarding/SeedPhrase/SwiftUI/SeedPuzzleViewModel.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import Combine
+import SwiftUI
 
 struct PuzzleElement: Hashable {
     let word: String
@@ -31,8 +32,12 @@ class SeedPuzzleViewModel: ObservableObject {
 
     private var puzzleItems = [Int: PuzzleElement]()
 
-    @Published var errorMessage = ""
     
+    // Error Handling
+    
+    @Published var errorMessage = ""
+    @Published var errorMessageColor: Color = Color(uiColor: UIColor.Theme.errorStringColor)
+
     private var seedphraseAlertString: String {
         let seedphraseWrongString = "You got it wrong!"
         let seedphraseCorrectString = "You passed the test"
@@ -92,6 +97,10 @@ class SeedPuzzleViewModel: ObservableObject {
                 guard let self else { return }
                 if self.isPuzzleComplete() {
                     self.errorMessage = self.seedphraseAlertString
+                    self.errorMessageColor = {
+                        let errColor = Color(uiColor: UIColor.Theme.errorStringColor)
+                        return self.seedphraseAlertString == "You passed the test" ? .green : errColor
+                    }()
                     self.resetPuzzle()
                 }
             }

--- a/DSNP-Wallet/Source/Modules/Onboarding/SeedPhrase/SwiftUI/SeedPuzzleViewModel.swift
+++ b/DSNP-Wallet/Source/Modules/Onboarding/SeedPhrase/SwiftUI/SeedPuzzleViewModel.swift
@@ -30,6 +30,12 @@ class SeedPuzzleViewModel: ObservableObject {
     var shuffledWordBankElements: [PuzzleElement]
 
     private var puzzleItems = [Int: PuzzleElement]()
+
+    var seedphraseAlertString: String {
+        let seedphraseWrongString = "The recovery phrase you entered is incorrect. Please try again."
+        let seedphraseCorrectString = "You passed the test"
+        return isPuzzleCorrect() ? seedphraseCorrectString : seedphraseWrongString
+    }
     
     // Observed vars
     @Published var continueEnabled: Bool = false

--- a/DSNP-Wallet/Source/Modules/Onboarding/SeedPhrase/SwiftUI/SeedPuzzleViewModel.swift
+++ b/DSNP-Wallet/Source/Modules/Onboarding/SeedPhrase/SwiftUI/SeedPuzzleViewModel.swift
@@ -34,7 +34,7 @@ class SeedPuzzleViewModel: ObservableObject {
     @Published var errorMessage = ""
     
     private var seedphraseAlertString: String {
-        let seedphraseWrongString = "The recovery phrase you entered is incorrect. Please try again."
+        let seedphraseWrongString = "You got it wrong!"
         let seedphraseCorrectString = "You passed the test"
         return isPuzzleCorrect() ? seedphraseCorrectString : seedphraseWrongString
     }
@@ -67,6 +67,7 @@ class SeedPuzzleViewModel: ObservableObject {
                 
                 self.inWordBankPuzzleElements = self.inWordBankPuzzleElements.filter { $0 != element }
                 self.continueEnabled = self.isPuzzleComplete()
+                self.errorMessage = ""
             }
             .store(in: &cancellables)
         deselectWordAction


### PR DESCRIPTION
# Seed Phrase Bug Fixes 

- This PR includes improvements from the follow up conversation concerning the seed flow

## Fixes/Improvements: 

1. Headline copy updated

<img width="237" alt="Screenshot 2023-05-31 at 2 36 30 PM" src="https://github.com/LibertyDSNP/dsnp-wallet-swift/assets/5061628/206a5d0d-6c23-49d0-aea4-0284a499de9e">

2. Increased minimum width for word bubbles within the puzzle column. This ultimately doesn't solve for very long words, but it is an ok shorter term solution for most longer words 

<img width="139" alt="Screenshot 2023-05-31 at 2 37 16 PM" src="https://github.com/LibertyDSNP/dsnp-wallet-swift/assets/5061628/50c0a44b-af0b-435c-a20f-967a7f06a15b">

3. Error Message updated. I also added a little bit of vertical padding to make the message more readable. We'll eventually transition to snackbar messaging before release, so this shouldn't be a show stopper.

<img width="312" alt="Screenshot 2023-05-31 at 2 39 18 PM" src="https://github.com/LibertyDSNP/dsnp-wallet-swift/assets/5061628/44e19fc5-71e0-46e8-a6cf-f17b348a529f">

3b. Removed alert view for success, using same message label as error to communicate success. We want to navigate to the original settings screen, but it's not built yet. 

<img width="311" alt="Screenshot 2023-05-31 at 2 41 08 PM" src="https://github.com/LibertyDSNP/dsnp-wallet-swift/assets/5061628/3b18fab6-ec0d-412e-8b77-60044dee7235">

4. Fix errant game logic, reset puzzle after the user has selected "continue"

